### PR TITLE
Improve error message in Tile constructor

### DIFF
--- a/mosaic-tiler/tile.mjs
+++ b/mosaic-tiler/tile.mjs
@@ -69,7 +69,7 @@ class Tile {
     this.image = image;
 
     if (!Number.isInteger(z) || !Number.isInteger(x) || !Number.isInteger(y)) {
-      throw new Error("z, x, y should b integer");
+      throw new Error(`z, x, y should b integer. input: z = ${z}, x = ${x}, y = ${y}`);
     }
     if (areZxyNotValid(z, x, y)) {
       throw new Error(`tile coordinates: ${z}/${x}/${y} are not valid`);


### PR DESCRIPTION
I see following error in prod logs but can't
figure what's wrong without having input z, x and y:
```
Error: z, x, y should b integer
    at new Tile (file:///usr/src/app/tile.mjs:72:13)
    at Tile.createEmpty (file:///usr/src/app/tile.mjs:62:12)
    at constructParentTileFromChildren (file:///usr/src/app/tile.mjs:118:17)
    at source (file:///usr/src/app/mosaic.mjs:161:24)
    at async Promise.all (index 0)
    at async source (file:///usr/src/app/mosaic.mjs:154:19)
    at async Promise.all (index 0)
    at async source (file:///usr/src/app/mosaic.mjs:154:19)
    at async Promise.all (index 0)
    at async source (file:///usr/src/app/mosaic.mjs:154:19)
```