### PR TITLE
Remove bulk delete in cache invalidation job

### DIFF
--- a/mosaic-tiler/src/mosaic_cache_invalidation_job.mjs
+++ b/mosaic-tiler/src/mosaic_cache_invalidation_job.mjs
@@ -53,15 +53,7 @@ async function invalidateMosaicCache() {
       }
     }
   }
-  if (invalidTilePaths.length > 2_000_000) {
-    // NOTE: if there are too many "mosaic" tiles to invalid it is much
-    // faster to delete the whole "mosaic" cache. it is ok to purge "mosaic"
-    // cache because cache of "pieces" will still be there so it is fast
-    // to rebuild "mosaic" cache.
-    await cachePurgeMosaic();
-  } else {
-    await Promise.all(invalidTilePaths.map((path) => cacheDelete(path)));
-  }
+  await Promise.all(invalidTilePaths.map((path) => cacheDelete(path)));
 
   await cachePut(
     Buffer.from(


### PR DESCRIPTION
Currently rebuilding whole `__mosaic__` directory cache might take several hours = mosaic not available.