### PR TITLE
Add missing not optional arguments in `Tile.createEmpty` call

### DIFF
--- a/mosaic-tiler/src/tile.mjs
+++ b/mosaic-tiler/src/tile.mjs
@@ -115,7 +115,7 @@ export { Tile, TileImage };
 async function constructParentTileFromChildren(tiles, z, x, y) {
   const notEmptyTiles = tiles.filter((tile) => !tile.empty());
   if (!notEmptyTiles.length) {
-    return Tile.createEmpty();
+    return Tile.createEmpty(z, x, y);
   }
 
   let tileSize = notEmptyTiles[0].image.tileSize;


### PR DESCRIPTION
This is the fix for following error that is currently present in logs of production pod:
```
Error: z, x, y should b integer. iwnput: z = undefined, x = undefined, y = undefined
    at new Tile (file:///usr/src/app/src/tile.mjs:72:13)
    at Tile.createEmpty (file:///usr/src/app/src/tile.mjs:62:12)
    at constructParentTileFromChildren (file:///usr/src/app/src/tile.mjs:118:17)
    at source (file:///usr/src/app/src/mosaic.mjs:60:24)
    at async Promise.all (index 3)
    at async source (file:///usr/src/app/src/mosaic.mjs:53:19)
    at async Promise.all (index 1)
    at async source (file:///usr/src/app/src/mosaic.mjs:53:19)
    at async Promise.all (index 1)
    at async source (file:///usr/src/app/src/mosaic.mjs:53:19)
```