### PR TITLE
Fix deleted images cache invalidation to affect lower zooms

### DIFF
--- a/__tests__/mosaic.mjs
+++ b/__tests__/mosaic.mjs
@@ -376,6 +376,8 @@ test("mosaic cache invalidation [delete]", async () => {
   await cache.put(Buffer.from(JSON.stringify(infoBefore)), "__info__.json");
 
   await Promise.all([
+    cache.put(null, "__mosaic__/0/0/0.png"),
+    cache.put(null, "__mosaic__/0/0/0.jpg"),
     cache.put(null, "__mosaic__/11/1233/637.png"),
     cache.put(null, "__mosaic256px__/12/2466/1274.png"),
     cache.put(null, "__mosaic__/11/1233/637.jpg"),

--- a/src/mosaic_cache_invalidation_job.mjs
+++ b/src/mosaic_cache_invalidation_job.mjs
@@ -26,6 +26,26 @@ function geojsonGeometryFromBounds(topLeft, bottomRight) {
   };
 }
 
+function getStaleCacheKeysForImage(geojson, maxzoom) {
+  const staleCacheKeys = new Set();
+  for (let zoom = 0; zoom <= maxzoom; ++zoom) {
+    for (const [x, y, z] of getTileCover(geojson, zoom)) {
+      staleCacheKeys.add(`__mosaic__/${z}/${x}/${y}.png`);
+      staleCacheKeys.add(`__mosaic__/${z}/${x}/${y}.jpg`);
+      staleCacheKeys.add(`__mosaic256px__/${z + 1}/${x * 2}/${y * 2}.png`);
+      staleCacheKeys.add(`__mosaic256px__/${z + 1}/${x * 2 + 1}/${y * 2}.png`);
+      staleCacheKeys.add(`__mosaic256px__/${z + 1}/${x * 2}/${y * 2 + 1}.png`);
+      staleCacheKeys.add(`__mosaic256px__/${z + 1}/${x * 2 + 1}/${y * 2 + 1}.png`);
+      staleCacheKeys.add(`__mosaic256px__/${z + 1}/${x * 2}/${y * 2}.jpg`);
+      staleCacheKeys.add(`__mosaic256px__/${z + 1}/${x * 2 + 1}/${y * 2}.jpg`);
+      staleCacheKeys.add(`__mosaic256px__/${z + 1}/${x * 2}/${y * 2 + 1}.jpg`);
+      staleCacheKeys.add(`__mosaic256px__/${z + 1}/${x * 2 + 1}/${y * 2 + 1}.jpg`);
+    }
+  }
+
+  return staleCacheKeys;
+}
+
 async function invalidateMosaicCache() {
   const cacheInfo = JSON.parse(await cacheGet("__info__.json"));
   const lastUpdated = new Date(cacheInfo.last_updated);
@@ -87,22 +107,9 @@ async function invalidateMosaicCache() {
       const metadata = JSON.parse(metadataBuffer.toString());
       const { bounds, maxzoom } = metadata;
       const geojson = geojsonGeometryFromBounds(bounds.slice(0, 2), bounds.slice(2));
-      for (let zoom = 0; zoom <= maxzoom; ++zoom) {
-        for (const [x, y, z] of getTileCover(geojson, zoom)) {
-          const staleCacheKeys = [];
-          staleCacheKeys.push(`__mosaic__/${z}/${x}/${y}.png`);
-          staleCacheKeys.push(`__mosaic__/${z}/${x}/${y}.jpg`);
-          staleCacheKeys.push(`__mosaic256px__/${z + 1}/${x * 2}/${y * 2}.png`);
-          staleCacheKeys.push(`__mosaic256px__/${z + 1}/${x * 2 + 1}/${y * 2}.png`);
-          staleCacheKeys.push(`__mosaic256px__/${z + 1}/${x * 2}/${y * 2 + 1}.png`);
-          staleCacheKeys.push(`__mosaic256px__/${z + 1}/${x * 2 + 1}/${y * 2 + 1}.png`);
-          staleCacheKeys.push(`__mosaic256px__/${z + 1}/${x * 2}/${y * 2}.jpg`);
-          staleCacheKeys.push(`__mosaic256px__/${z + 1}/${x * 2 + 1}/${y * 2}.jpg`);
-          staleCacheKeys.push(`__mosaic256px__/${z + 1}/${x * 2}/${y * 2 + 1}.jpg`);
-          staleCacheKeys.push(`__mosaic256px__/${z + 1}/${x * 2 + 1}/${y * 2 + 1}.jpg`);
-          for (const key of staleCacheKeys) {
-            await cacheDelete(key);
-          }
+      for (const staleCacheKey of getStaleCacheKeysForImage(geojson, maxzoom)) {
+        if (presentMosaicCacheKeys.has(staleCacheKey)) {
+          await cacheDelete(staleCacheKey);
         }
       }
 
@@ -120,22 +127,9 @@ async function invalidateMosaicCache() {
         latestUploadedAt = row.uploaded_at;
       }
       const { maxzoom } = await getGeotiffMetadata(url);
-      for (let zoom = 0; zoom <= maxzoom; ++zoom) {
-        for (const [x, y, z] of getTileCover(geojson, zoom)) {
-          const staleCacheKeys = [];
-          staleCacheKeys.push(`__mosaic__/${z}/${x}/${y}.png`);
-          staleCacheKeys.push(`__mosaic__/${z}/${x}/${y}.jpg`);
-          staleCacheKeys.push(`__mosaic256px__/${z + 1}/${x * 2}/${y * 2}.png`);
-          staleCacheKeys.push(`__mosaic256px__/${z + 1}/${x * 2 + 1}/${y * 2}.png`);
-          staleCacheKeys.push(`__mosaic256px__/${z + 1}/${x * 2}/${y * 2 + 1}.png`);
-          staleCacheKeys.push(`__mosaic256px__/${z + 1}/${x * 2 + 1}/${y * 2 + 1}.png`);
-          staleCacheKeys.push(`__mosaic256px__/${z + 1}/${x * 2}/${y * 2}.jpg`);
-          staleCacheKeys.push(`__mosaic256px__/${z + 1}/${x * 2 + 1}/${y * 2}.jpg`);
-          staleCacheKeys.push(`__mosaic256px__/${z + 1}/${x * 2}/${y * 2 + 1}.jpg`);
-          staleCacheKeys.push(`__mosaic256px__/${z + 1}/${x * 2 + 1}/${y * 2 + 1}.jpg`);
-          for (const key of staleCacheKeys) {
-            await cacheDelete(key);
-          }
+      for (const staleCacheKey of getStaleCacheKeysForImage(geojson, maxzoom)) {
+        if (presentMosaicCacheKeys.has(staleCacheKey)) {
+          await cacheDelete(staleCacheKey);
         }
       }
     }


### PR DESCRIPTION
Rewrite cache invalidation in the same way it works for newly added images: compute tile coverage and remove matching tiles from the cache.

Previous approach made wrong assumption that every cached tile of individual image has matching mosaic z, x, y cached tile. That is not true because currently tiles of individual images are cached only on zoom levels >= 9. On 0-10 zoom levels mosaic tiles are build from downscaled mosaic tiles.