### PR TITLE
Increase memory limit to 4 gb

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,4 +7,4 @@ COPY . .
 
 EXPOSE 8080
 
-CMD [ "node", "src/main.mjs" ]
+CMD [ "node", "--max-old-space-size=4096", "src/main.mjs" ]


### PR DESCRIPTION
Temporary (I hope) fix for the problem that currently cache invalidation job is running out of memory because the set with invalidate cache keys is getting too large.