### PR TITLE
Add logging to get cached metadata fn

### DIFF
--- a/src/metadata.mjs
+++ b/src/metadata.mjs
@@ -1,12 +1,18 @@
 import { cacheGet, cachePut } from "./cache.mjs";
 import { enqueueMetadataFetching } from "./titiler_fetcher.mjs";
 import { keyFromS3Url } from "./key_from_s3_url.mjs";
+import { logger } from "./logging.mjs";
 
 async function cacheGetMetadata(key) {
+  logger.debug(`Got metadata key: ${key}`);
+
   const buffer = await cacheGet(`__metadata__/${key}.json`);
   if (buffer === null) {
     return null;
   }
+
+  logger.debug(`Cached metadata buffer: ${buffer}`);
+  logger.debug(`Cached metadata buffer string: ${buffer.toString()}`);
 
   return JSON.parse(buffer.toString());
 }


### PR DESCRIPTION
Extend logging

https://kontur.fibery.io/Tasks/Task/OAM-prod-500-error-when-browsing-and-zooming-in-out-imagery-in-mosaic-16321