### PR TITLE
Implement batch processing in mosaic cache invalidation

### DIFF
--- a/src/mosaic_cache_invalidation_job.mjs
+++ b/src/mosaic_cache_invalidation_job.mjs
@@ -159,17 +159,17 @@ async function invalidateMosaicCache() {
         await invalidateImage(geojson, maxzoom, mosaicCacheKeys);
       }
     }
-  }
 
-  if (imagesAddedSinceLastInvalidation.length > 0) {
-    await cachePut(
-      Buffer.from(
-        JSON.stringify({
-          last_updated: latestUploadedAt,
-        })
-      ),
-      "__info__.json"
-    );
+    if (imagesAddedSinceLastInvalidation.length > 0) {
+      await cachePut(
+        Buffer.from(
+          JSON.stringify({
+            last_updated: latestUploadedAt,
+          })
+        ),
+        "__info__.json"
+      );
+    }
   }
 
   logger.debug("Mosaic cache invalidation ended");


### PR DESCRIPTION
This commit introduces a mechanism to handle large sets of mosaic cache keys by processing them in batches. When the set size reaches a predefined maximum (MAX_SET_SIZE), the current batch is processed, and the set is cleared to make room for new entries. This change ensures that the cache invalidation job can handle large volumes of data without running into memory constraints. Additionally, the commit includes a final call to process any remaining keys after iterating through all mosaic tiles. This improvement optimizes the cache invalidation process, making it more efficient and reliable.

https://kontur.fibery.io/Tasks/Task/prod-raster-tiler-error-in-invalidateMosaicCache-15257

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Improved the efficiency of mosaic cache handling by introducing batch processing when a set size limit is reached.
	- Added a constant `MAX_SET_SIZE` with a value of 1,000,000.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->