### PR TITLE
Enhance cachePurgeMosaic to remove mosaic256 as well

### DIFF
--- a/src/cache.mjs
+++ b/src/cache.mjs
@@ -37,8 +37,9 @@ async function cacheInit() {
   }
 }
 
-function cachePurgeMosaic() {
-  return fs.promises.rmdir(`${TILES_CACHE_DIR_PATH}/__mosaic__`);
+async function cachePurgeMosaic() {
+  await fs.promises.rmdir(`${TILES_CACHE_DIR_PATH}/__mosaic__`, { recursive: true });
+  await fs.promises.rmdir(`${TILES_CACHE_DIR_PATH}/__mosaic256__`, { recursive: true });
 }
 
 function mosaicTilesIterable() {

--- a/src/cache.mjs
+++ b/src/cache.mjs
@@ -38,8 +38,20 @@ async function cacheInit() {
 }
 
 async function cachePurgeMosaic() {
-  await fs.promises.rmdir(`${TILES_CACHE_DIR_PATH}/__mosaic__`, { recursive: true });
-  await fs.promises.rmdir(`${TILES_CACHE_DIR_PATH}/__mosaic256__`, { recursive: true });
+  try {
+    await Promise.all([
+      fs.promises.rmdir(`${TILES_CACHE_DIR_PATH}/__mosaic__`, { recursive: true }),
+      fs.promises.rmdir(`${TILES_CACHE_DIR_PATH}/__mosaic256__`, { recursive: true })
+    ]);
+    // Recreate directories to maintain consistency with cacheInit
+    await Promise.all([
+      fs.promises.mkdir(`${TILES_CACHE_DIR_PATH}/__mosaic__`, { recursive: true }),
+      fs.promises.mkdir(`${TILES_CACHE_DIR_PATH}/__mosaic256__`, { recursive: true })
+    ]);
+  } catch (error) {
+    throw new Error(`Failed to purge mosaic cache: ${error.message}`);
+  }
+}
 }
 
 function mosaicTilesIterable() {


### PR DESCRIPTION
https://kontur.fibery.io/Tasks/Task/Mosaic-cache-reset-endpoint-should-reset-256px-tiles-too-20065

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Enhanced the cache purging functionality to remove both `__mosaic__` and `__mosaic256__` directories asynchronously, improving cached data management.

- **Bug Fixes**
  - Improved error handling in the cache management process, ensuring robust performance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->