### PR TITLE
Implement front/back plane tile rendering

### DIFF
--- a/src/filters.mjs
+++ b/src/filters.mjs
@@ -104,17 +104,22 @@ export function buildParametrizedFiltersQuery(OAM_LAYER_ID, z, x, y, filters = {
   const sqlQuery = `with oam_meta as (
     select
       feature_id,
-      (properties->>'gsd')::real as resolution_in_meters, 
+      (properties->>'gsd')::real as resolution_in_meters,
       (properties->>'acquisition_end')::timestamptz as acquisition_end,
-      properties->>'uuid' as uuid, 
+      (properties->>'uploaded_at')::timestamptz as uploaded_at,
+      properties->>'uuid' as uuid,
       geom
     from public.layers_features
     where layer_id = (select id from public.layers where public_id = '${OAM_LAYER_ID}')
   )
-  select uuid, ST_AsGeoJSON(ST_Envelope(geom)) geojson
+  select uuid,
+         ST_AsGeoJSON(ST_Envelope(geom)) geojson,
+         resolution_in_meters,
+         acquisition_end,
+         uploaded_at
   from oam_meta
   where ${sqlWhereClause}
-  order by resolution_in_meters desc nulls last, acquisition_end desc nulls last, feature_id asc`;
+  order by feature_id asc`;
 
   return { sqlQuery, sqlQueryParams, queryTag: tags.join("_") };
 }


### PR DESCRIPTION
## Summary
- introduce preferred palette and back-plane blending
- expose uploaded/resolution metadata from SQL
- sort front/back tiles and overlay
- update tile blender with new blendBackTiles

## Testing
- `npm test` *(fails: RequestError ENOTFOUND test-apps02.konturlabs.com)*

------
https://chatgpt.com/codex/tasks/task_e_68339a2405908324bc3c0a65d5b694c1

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Improved tile blending for map mosaics, now using a two-layer approach that prioritizes higher-resolution imagery and preferred color palettes for better visual quality.
  - Additional metadata, including upload date and file size, is now available for each map tile.

- **Improvements**
  - Enhanced sorting of imagery tiles based on resolution, upload date, and zoom level for more accurate and visually appealing mosaics.
  - More precise handling and display of tile metadata in map results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->