### PR TITLE
feat: Introduce child tile assembly controls to optimize performance

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,6 +138,8 @@ const levels = {
 | `DB_DISABLE_SSL`        | Disable SSL for PostgreSQL connection                                                                     | `false`         |
 | `TILE_FETCH_TIMEOUT_MS` | Maximum time to wait for tile fetch (ms). Requests exceeding this timeout will fail with a timeout error. | `60000`         |
 | `FETCH_QUEUE_TTL_MS`    | Time to keep fetch promises in memory (ms). Older promises are removed to prevent memory leaks.           | `600000`        |
+| `CHILD_ASSEMBLY_MAX_ZOOM` | Max zoom at which assembling a parent tile from its four children is allowed. If `0`, assembly is disabled. | `0`           |
+| `CHILD_ASSEMBLY_MAX_DEPTH` | Max recursion depth for child assembly. If `0`, assembly is disabled.                                     | `0`           |
 
 ## Tests
 

--- a/docs/child_tile_assembly.md
+++ b/docs/child_tile_assembly.md
@@ -1,0 +1,71 @@
+# Controlling Child Tile Assembly and Recursion
+
+## Overview
+
+This change introduces configuration to control or disable assembling a parent tile from its four children ("child assembly"). The goal is to reduce CPU load and request fan-out at low zoom levels, which can otherwise cause large queues in the raster processing pipeline.
+
+## What Was Changed
+
+1. Child assembly gating by zoom
+   - New env var: `CHILD_ASSEMBLY_MAX_ZOOM`.
+   - Behavior:
+     - If `CHILD_ASSEMBLY_MAX_ZOOM = 0` (default), child assembly is fully disabled.
+     - If `CHILD_ASSEMBLY_MAX_ZOOM > 0`, assembly is allowed only for zooms `z < CHILD_ASSEMBLY_MAX_ZOOM`.
+
+2. Recursion depth limit
+   - New env var: `CHILD_ASSEMBLY_MAX_DEPTH`.
+   - Behavior:
+     - If `CHILD_ASSEMBLY_MAX_DEPTH = 0` (default), child assembly is fully disabled.
+     - If `CHILD_ASSEMBLY_MAX_DEPTH > 0`, recursion is allowed only while `depth < CHILD_ASSEMBLY_MAX_DEPTH`.
+
+3. Integration points
+   - Per-image tile path (`source(...)` in `src/mosaic.mjs`):
+     - Child assembly path executes only when both zoom and depth constraints are satisfied and `z < meta.maxzoom`.
+   - Mosaic path (`buildRowTilePromises(...)` in `src/mosaic.mjs`):
+     - The optional `parentTilePromise` (assemble parent from 4 children) is created only if both constraints are satisfied.
+
+4. Robustness fixes
+   - `Tile.extractChild(...)` (in `src/tile.mjs`) now always returns a `Tile` (returns an empty `Tile` when the image is empty) to avoid ambiguous return types.
+   - `mosaic256px(...)` uses `await tile.transformInJpegIfFullyOpaque()` to avoid accessing internals directly.
+
+## Rationale
+
+- Child assembly can trigger an exponential fan-out of work at low zoom levels, especially with a cold cache.
+- Limiting by zoom and depth reduces CPU usage, TiTiler traffic, and queue buildup while keeping the behavior configurable per environment.
+
+## Configuration
+
+```bash
+# Disable child assembly entirely (default)
+export CHILD_ASSEMBLY_MAX_ZOOM=0
+export CHILD_ASSEMBLY_MAX_DEPTH=0
+
+# Enable assembly below z=9 with up to 2 levels of recursion
+export CHILD_ASSEMBLY_MAX_ZOOM=9
+export CHILD_ASSEMBLY_MAX_DEPTH=2
+
+# Enable assembly broadly (use with caution)
+export CHILD_ASSEMBLY_MAX_ZOOM=24
+export CHILD_ASSEMBLY_MAX_DEPTH=8
+```
+
+Notes:
+- Both constraints must be satisfied for assembly to run.
+- If either value is `0` (or non-numeric), assembly is disabled.
+
+## Impact
+
+- Lower CPU and fewer concurrent requests at low zoom levels.
+- Potentially less detail at very low zooms if parent tiles previously relied on assembling from children; this is controllable via the env settings above.
+- No changes to outlines/clusters endpoints; only the mosaic tile pipeline is affected.
+
+## Files Touched
+
+- `src/mosaic.mjs`:
+  - Added `CHILD_ASSEMBLY_MAX_ZOOM` and `CHILD_ASSEMBLY_MAX_DEPTH` gates.
+  - Plumbed recursion depth through `source(...)`, `mosaic512px(...)`, and `buildRowTilePromises(...)`.
+  - Adjusted JPEG conversion call site.
+- `src/tile.mjs`:
+  - `Tile.extractChild(...)` now returns a `Tile` in all cases.
+
+

--- a/src/tile.mjs
+++ b/src/tile.mjs
@@ -101,7 +101,7 @@ class Tile {
     }
 
     if (this.image.empty()) {
-      return this.image;
+      return Tile.createEmpty(z, x, y);
     }
 
     const image = await this.image.extractChild(x % 2, y % 2);


### PR DESCRIPTION
- Added environment variables `CHILD_ASSEMBLY_MAX_ZOOM` and `CHILD_ASSEMBLY_MAX_DEPTH` to manage child tile assembly based on zoom level and recursion depth.
- Updated the `source` function to conditionally assemble parent tiles from children based on the new configuration.
- Enhanced the mosaic tile fetching logic to respect the new assembly constraints, reducing CPU load and request fan-out at low zoom levels.
- Documented the new configuration options in `child_tile_assembly.md` for clarity.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added environment variables to control child tile assembly and recursion depth (CHILD_ASSEMBLY_MAX_ZOOM, CHILD_ASSEMBLY_MAX_DEPTH). Configurable per environment; improves performance at low zooms.

- Bug Fixes
  - More robust handling of empty tiles and image transforms to avoid errors and ensure consistent behavior.

- Documentation
  - Updated README with new environment variables.
  - Added a dedicated guide explaining child tile assembly, configuration examples, and expected impacts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->