### PR TITLE
feat: Implement mosaic cache key parsing and enhance cache invalidation logic

### DIFF
--- a/src/cache.mjs
+++ b/src/cache.mjs
@@ -127,6 +127,14 @@ async function cacheDelete(key) {
   }
 }
 
+async function cacheDeleteBothExtensions(baseKeyWithoutExtension) {
+  // Delete both .png and .jpg variants if exist; ignore if missing
+  await Promise.allSettled([
+    cacheDelete(`${baseKeyWithoutExtension}.png`),
+    cacheDelete(`${baseKeyWithoutExtension}.jpg`),
+  ]);
+}
+
 async function cachePut(buffer, key) {
   const path = `${TILES_CACHE_DIR_PATH}/${key}`;
   if (!fs.existsSync(dirname(path))) {
@@ -150,6 +158,7 @@ export {
   cacheGet,
   cachePut,
   cacheDelete,
+  cacheDeleteBothExtensions,
   mosaicTilesIterable,
   metadataJsonsIterable,
   singleImageTilesIterable,


### PR DESCRIPTION


- Added a new function to parse mosaic cache keys, supporting both __mosaic__ and __mosaic256__ formats.
- Introduced a method to invalidate images using present cache keys, improving the efficiency of cache invalidation by precomputing tile covers.
- Enhanced error handling during metadata fetching, allowing fallback to present-keys invalidation if metadata is missing or fetch fails.
- Updated the main cache invalidation function to track whether any invalidations occurred, ensuring proper cache updates.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Per-image maxzoom invalidation when metadata is available; configurable invalidation interval; helper to delete PNG/JPG variants in parallel.

* **Bug Fixes**
  * Ensures invalidation still works when metadata is missing or metadata fetch fails; processes deleted-image invalidation once per run.

* **Performance**
  * Dynamic batch sizing for key processing (env-configurable) and batch-based workflow to reduce work.

* **Reliability**
  * Non-overlapping runs via run guard, stronger fallbacks, and only update index/state when real invalidations occur.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->